### PR TITLE
Add RegMem few-shot anomaly detection pipeline

### DIFF
--- a/src/anomalib/models/components/regmem/__init__.py
+++ b/src/anomalib/models/components/regmem/__init__.py
@@ -1,0 +1,29 @@
+"""Feature registration and memory components for few-shot anomaly detection.
+
+This package bundles reusable building blocks that are shared across the
+few-shot registration-memory (RegMem) pipeline:
+
+* :mod:`registration` - differentiable feature registration networks that
+  align support and query representations.
+* :mod:`memory_bank` - utilities to construct a compact memory bank of normal
+  patch descriptors with greedy coreset sampling.
+* :mod:`distribution` - distribution estimators that mix Mahalanobis distance,
+  Mahalanobis++ normalisation and maximum mean discrepancy (MMD) metrics.
+
+The components are implemented as lightweight, well documented PyTorch modules
+so that they can be reused in other research prototypes without depending on
+the high level Lightning interface.
+"""
+
+from .distribution import DistributionEstimator, MahalanobisStatistics
+from .memory_bank import PatchMemoryBank
+from .registration import FeatureRegistrationModule, RegistrationOutputs
+
+__all__ = [
+    "DistributionEstimator",
+    "FeatureRegistrationModule",
+    "MahalanobisStatistics",
+    "PatchMemoryBank",
+    "RegistrationOutputs",
+]
+

--- a/src/anomalib/models/components/regmem/distribution.py
+++ b/src/anomalib/models/components/regmem/distribution.py
@@ -1,0 +1,85 @@
+"""Distribution estimators for registered patch features."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+from torch import Tensor, nn
+
+
+@dataclass
+class MahalanobisStatistics:
+    """Container storing statistics required for Mahalanobis distances."""
+
+    mean: Tensor
+    covariance_inv: Tensor
+
+
+def _compute_mahalanobis_stats(features: Tensor, eps: float = 1e-6) -> MahalanobisStatistics:
+    mean = features.mean(dim=0, keepdim=True)
+    centered = features - mean
+    covariance = centered.T @ centered / max(1, features.shape[0] - 1)
+    covariance = covariance + eps * torch.eye(covariance.shape[0], device=covariance.device, dtype=covariance.dtype)
+    covariance_inv = torch.linalg.pinv(covariance)
+    return MahalanobisStatistics(mean=mean, covariance_inv=covariance_inv)
+
+
+def _mahalanobis_distance(features: Tensor, stats: MahalanobisStatistics) -> Tensor:
+    centered = features - stats.mean
+    left = centered @ stats.covariance_inv
+    return (left * centered).sum(dim=1)
+
+
+def _normalize(features: Tensor) -> Tensor:
+    return torch.nn.functional.normalize(features, dim=1)
+
+
+def _gaussian_kernel(x: Tensor, y: Tensor, sigma: float = 1.0) -> Tensor:
+    return torch.exp(-torch.cdist(x, y, p=2) ** 2 / (2 * sigma**2))
+
+
+class DistributionEstimator(nn.Module):
+    """Hybrid distribution estimator combining multiple distance metrics."""
+
+    def __init__(
+        self,
+        combine_weights: tuple[float, float, float] = (0.5, 0.3, 0.2),
+        mmd_sigma: float = 1.0,
+    ) -> None:
+        super().__init__()
+        self.combine_weights = combine_weights
+        self.mmd_sigma = mmd_sigma
+        self.stats: dict[str, MahalanobisStatistics] = {}
+        self.stats_pp: dict[str, MahalanobisStatistics] = {}
+        self.memory_features: dict[str, Tensor] = {}
+
+    def fit(self, memory: dict[str, Tensor]) -> None:
+        self.stats.clear()
+        self.stats_pp.clear()
+        self.memory_features = {layer: feats for layer, feats in memory.items()}
+        for layer, feats in memory.items():
+            self.stats[layer] = _compute_mahalanobis_stats(feats)
+            self.stats_pp[layer] = _compute_mahalanobis_stats(_normalize(feats))
+
+    def _mahalanobis(self, layer: str, features: Tensor) -> Tensor:
+        return _mahalanobis_distance(features, self.stats[layer])
+
+    def _mahalanobis_pp(self, layer: str, features: Tensor) -> Tensor:
+        return _mahalanobis_distance(_normalize(features), self.stats_pp[layer])
+
+    def _mmd(self, layer: str, features: Tensor) -> Tensor:
+        memory = self.memory_features[layer]
+        kernel_xx = _gaussian_kernel(features, features, sigma=self.mmd_sigma)
+        kernel_yy = _gaussian_kernel(memory, memory, sigma=self.mmd_sigma)
+        kernel_xy = _gaussian_kernel(features, memory, sigma=self.mmd_sigma)
+        mmd = kernel_xx.mean(dim=1) + kernel_yy.mean() - 2 * kernel_xy.mean(dim=1)
+        return mmd
+
+    def score(self, layer: str, features: Tensor) -> Tensor:
+        m = self._mahalanobis(layer, features)
+        mpp = self._mahalanobis_pp(layer, features)
+        mmd = self._mmd(layer, features)
+        w1, w2, w3 = self.combine_weights
+        return w1 * m + w2 * mpp + w3 * mmd
+

--- a/src/anomalib/models/components/regmem/memory_bank.py
+++ b/src/anomalib/models/components/regmem/memory_bank.py
@@ -1,0 +1,126 @@
+"""Patch memory bank construction utilities."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Dict
+
+import torch
+from torch import Tensor, nn
+
+
+def _flatten_patches(features: Tensor) -> Tensor:
+    """Flatten spatial dimensions to create patch descriptors."""
+
+    batch, channels, height, width = features.shape
+    return features.permute(0, 2, 3, 1).reshape(batch * height * width, channels)
+
+
+def _normalize_weights(weights: Tensor | None, num_items: int, device: torch.device) -> Tensor:
+    if weights is None:
+        return torch.ones(num_items, device=device)
+    if weights.ndim == 0:
+        return torch.full((num_items,), float(weights), device=device)
+    if weights.numel() != num_items:
+        msg = "Number of weights must match number of items."
+        raise ValueError(msg)
+    return weights.to(device=device)
+
+
+def greedy_coreset(features: Tensor, num_samples: int) -> tuple[Tensor, torch.Tensor]:
+    """Greedy coreset selection used in PatchCore.
+
+    Returns both sampled features and the indices of the selected samples.
+    """
+
+    if num_samples >= features.shape[0]:
+        indices = torch.arange(features.shape[0], device=features.device)
+        return features, indices
+
+    remaining = features
+    selected_indices: list[int] = []
+    idx = torch.randint(0, remaining.shape[0], (1,), device=features.device).item()
+    selected_indices.append(idx)
+    selected = remaining[idx].unsqueeze(0)
+    min_distances = torch.full((remaining.shape[0],), float("inf"), device=features.device)
+
+    for _ in range(1, num_samples):
+        distances = torch.cdist(selected[-1].unsqueeze(0), remaining, p=2).squeeze(0)
+        min_distances = torch.minimum(min_distances, distances)
+        next_idx = int(torch.argmax(min_distances).item())
+        selected_indices.append(next_idx)
+        selected = torch.cat([selected, remaining[next_idx].unsqueeze(0)], dim=0)
+
+    indices = torch.tensor(selected_indices, device=features.device)
+    return features[indices], indices
+
+
+@dataclass
+class MemoryBankItem:
+    """Store sampled features and optional weights for a single layer."""
+
+    features: Tensor
+    weights: Tensor
+
+
+class PatchMemoryBank(nn.Module):
+    """Build a compact memory bank of registered patch descriptors."""
+
+    def __init__(
+        self,
+        layers: list[str],
+        coreset_sampling_ratio: float = 0.05,
+        device: torch.device | None = None,
+    ) -> None:
+        super().__init__()
+        self.layers = layers
+        self.coreset_sampling_ratio = coreset_sampling_ratio
+        self.device = device
+        self.reset()
+
+    def reset(self) -> None:
+        self.register_buffer("_is_built", torch.tensor(False), persistent=True)
+        self._storage: dict[str, list[Tensor]] = {layer: [] for layer in self.layers}
+        self._weights: dict[str, list[Tensor]] = {layer: [] for layer in self.layers}
+        self.memory: dict[str, MemoryBankItem] = {}
+
+    def update(self, features: Mapping[str, Tensor], weights: Mapping[str, Tensor] | None = None) -> None:
+        """Accumulate support features prior to coreset sampling."""
+
+        weights = weights or {}
+        for layer in self.layers:
+            feats = _flatten_patches(features[layer].detach())
+            weight = weights.get(layer)
+            if weight is not None:
+                weight = weight.reshape(-1)
+            self._storage[layer].append(feats.cpu())
+            if weight is not None:
+                self._weights[layer].append(weight.cpu())
+
+    def build(self) -> None:
+        """Apply greedy coreset sampling and finalise the memory bank."""
+
+        device = self.device or torch.device("cpu")
+        self.memory.clear()
+        for layer in self.layers:
+            if not self._storage[layer]:
+                continue
+            features = torch.cat(self._storage[layer], dim=0).to(device)
+            if self._weights[layer]:
+                weights = torch.cat(self._weights[layer], dim=0).to(device)
+            else:
+                weights = torch.ones(features.shape[0], device=device)
+            num_samples = max(1, int(features.shape[0] * self.coreset_sampling_ratio))
+            sampled, indices = greedy_coreset(features, num_samples=num_samples)
+            sampled_weights = _normalize_weights(weights[indices], sampled.shape[0], device=device)
+            self.memory[layer] = MemoryBankItem(features=sampled, weights=sampled_weights)
+
+        self._is_built = torch.tensor(True, device=device)
+
+    def __len__(self) -> int:
+        return sum(item.features.shape[0] for item in self.memory.values())
+
+    def get(self, layer: str) -> MemoryBankItem:
+        return self.memory[layer]
+

--- a/src/anomalib/models/components/regmem/registration.py
+++ b/src/anomalib/models/components/regmem/registration.py
@@ -1,0 +1,177 @@
+"""Differentiable feature registration modules.
+
+The registration network aligns support and query feature maps so that
+subsequent distance computations operate on spatially consistent patch
+representations.  The implementation is intentionally lightweight to keep the
+dependency surface small while still providing:
+
+* pyramid-style registration blocks with learned optical-flow predictions
+* symmetric cosine-similarity losses that encourage cycle consistency
+* hooks to keep track of running prototypes for each feature level
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Dict
+
+import torch
+from torch import Tensor, nn
+from torch.nn import functional as F
+
+from anomalib.models.components.feature_extractors import TimmFeatureExtractor
+
+
+def _identity_grid(height: int, width: int, device: torch.device, dtype: torch.dtype) -> Tensor:
+    """Create a normalised ``[-1, 1]`` sampling grid."""
+
+    ys, xs = torch.linspace(-1, 1, steps=height, device=device, dtype=dtype), torch.linspace(
+        -1, 1, steps=width, device=device, dtype=dtype
+    )
+    grid_y, grid_x = torch.meshgrid(ys, xs, indexing="ij")
+    return torch.stack((grid_x, grid_y), dim=-1)
+
+
+class RegistrationBlock(nn.Module):
+    """Predict a dense flow field that warps support features onto query features."""
+
+    def __init__(self, channels: int, hidden_channels: int = 128, flow_scale: float = 0.5) -> None:
+        super().__init__()
+        self.encoder = nn.Sequential(
+            nn.Conv2d(channels * 2, hidden_channels, kernel_size=3, padding=1, bias=True),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(hidden_channels, hidden_channels // 2, kernel_size=3, padding=1, bias=True),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(hidden_channels // 2, 2, kernel_size=3, padding=1, bias=True),
+        )
+        self.flow_scale = flow_scale
+
+    def forward(self, support: Tensor, query: Tensor) -> Tensor:
+        """Warp ``support`` to match ``query``.
+
+        Args:
+            support: Support feature map of shape ``(B, C, H, W)``.
+            query: Query feature map of shape ``(B, C, H, W)``.
+        Returns:
+            Tensor: Support feature map spatially aligned to the query.
+        """
+
+        if support.shape != query.shape:
+            msg = "Support and query feature maps must share the same shape."
+            raise ValueError(msg)
+
+        features = torch.cat([support, query], dim=1)
+        flow = torch.tanh(self.encoder(features)) * self.flow_scale
+        grid = _identity_grid(query.shape[-2], query.shape[-1], device=query.device, dtype=query.dtype)
+        grid = grid.unsqueeze(0).expand(query.shape[0], -1, -1, -1)
+        grid = grid + flow.permute(0, 2, 3, 1)
+
+        aligned = F.grid_sample(support, grid, mode="bilinear", padding_mode="border", align_corners=True)
+        return aligned
+
+
+@dataclass
+class RegistrationOutputs:
+    """Container for registration outputs per feature level."""
+
+    support: Dict[str, Tensor]
+    query: Dict[str, Tensor]
+    aligned_support: Dict[str, Tensor]
+
+
+class FeatureRegistrationModule(nn.Module):
+    """Extract and register multi-level CNN features.
+
+    The module stores running prototypes for each level of the backbone and can
+    align arbitrary support/query batches against these prototypes.
+    """
+
+    def __init__(
+        self,
+        backbone: str = "resnet18",
+        layers: Sequence[str] = ("layer1", "layer2", "layer3"),
+        pre_trained: bool = True,
+        update_momentum: float = 0.1,
+    ) -> None:
+        super().__init__()
+        self.extractor = TimmFeatureExtractor(backbone=backbone, layers=layers, pre_trained=pre_trained)
+        self.registration_blocks = nn.ModuleDict({
+            layer: RegistrationBlock(channels=channels)
+            for layer, channels in zip(layers, self.extractor.out_dims, strict=True)
+        })
+        self.layers = list(layers)
+        self.update_momentum = update_momentum
+        self.register_buffer("prototypes_initialized", torch.tensor(False), persistent=True)
+        self.prototypes: dict[str, Tensor] = {}
+
+    def extract(self, images: Tensor) -> dict[str, Tensor]:
+        """Extract backbone features."""
+
+        return {layer: feat for layer, feat in self.extractor(images).items()}
+
+    def initialise_prototypes(self, features: dict[str, Tensor]) -> None:
+        """Initialise running prototypes from features."""
+
+        for layer, feat in features.items():
+            self.prototypes[layer] = feat.mean(dim=0, keepdim=True).detach()
+        self.prototypes_initialized = torch.tensor(True, device=features[self.layers[0]].device)
+
+    def _align_to_query(self, support: dict[str, Tensor], query: dict[str, Tensor]) -> RegistrationOutputs:
+        aligned_support: dict[str, Tensor] = {}
+        for layer in self.layers:
+            reg_block = self.registration_blocks[layer]
+            aligned_support[layer] = reg_block(support[layer], query[layer])
+        return RegistrationOutputs(support=support, query=query, aligned_support=aligned_support)
+
+    def register_support_batch(self, features: dict[str, Tensor]) -> dict[str, Tensor]:
+        """Align a batch of support features to running prototypes and update them."""
+
+        if not self.prototypes_initialized:
+            self.initialise_prototypes(features)
+            return {layer: feat.detach() for layer, feat in features.items()}
+
+        aligned: dict[str, Tensor] = {}
+        for layer in self.layers:
+            prototype = self.prototypes[layer]
+            support = features[layer]
+            prototype_expanded = prototype.expand_as(support)
+            aligned[layer] = self.registration_blocks[layer](support, prototype_expanded).detach()
+            momentum = self.update_momentum
+            proto_update = aligned[layer].mean(dim=0, keepdim=True)
+            self.prototypes[layer] = (1 - momentum) * prototype + momentum * proto_update
+        return aligned
+
+    def align_query_to_prototypes(self, query_features: dict[str, Tensor]) -> RegistrationOutputs:
+        """Align stored prototypes to a new query batch."""
+
+        if not self.prototypes_initialized:
+            self.initialise_prototypes(query_features)
+
+        support = {layer: self.prototypes[layer].expand_as(query_features[layer]) for layer in self.layers}
+        return self._align_to_query(support=support, query=query_features)
+
+    def compute_registration_loss(self, support_images: Tensor, query_images: Tensor) -> Tensor:
+        """Symmetric cosine similarity loss for registration."""
+
+        support_feats = self.extract(support_images)
+        query_feats = self.extract(query_images)
+
+        outputs = self._align_to_query(support_feats, query_feats)
+        loss = 0.0
+        for layer in self.layers:
+            aligned = outputs.aligned_support[layer]
+            query = outputs.query[layer]
+            cos = F.cosine_similarity(aligned, query, dim=1)
+            loss = loss + (1 - cos.mean())
+
+        # Symmetric term (query->support)
+        reverse_outputs = self._align_to_query(query_feats, support_feats)
+        for layer in self.layers:
+            aligned = reverse_outputs.aligned_support[layer]
+            support = reverse_outputs.query[layer]
+            cos = F.cosine_similarity(aligned, support, dim=1)
+            loss = loss + (1 - cos.mean())
+
+        return loss / (2 * len(self.layers))
+

--- a/src/anomalib/models/image/__init__.py
+++ b/src/anomalib/models/image/__init__.py
@@ -58,6 +58,7 @@ from .fre import Fre
 from .ganomaly import Ganomaly
 from .padim import Padim
 from .patchcore import Patchcore
+from .regmemfsad import RegMemFSAD
 from .reverse_distillation import ReverseDistillation
 from .stfpm import Stfpm
 from .supersimplenet import Supersimplenet
@@ -80,6 +81,7 @@ __all__ = [
     "Ganomaly",
     "Padim",
     "Patchcore",
+    "RegMemFSAD",
     "ReverseDistillation",
     "Stfpm",
     "Supersimplenet",

--- a/src/anomalib/models/image/regmemfsad/__init__.py
+++ b/src/anomalib/models/image/regmemfsad/__init__.py
@@ -1,0 +1,6 @@
+"""Registration + memory few-shot anomaly detection model."""
+
+from .lightning_model import RegMemFSAD
+
+__all__ = ["RegMemFSAD"]
+

--- a/src/anomalib/models/image/regmemfsad/lightning_model.py
+++ b/src/anomalib/models/image/regmemfsad/lightning_model.py
@@ -1,0 +1,96 @@
+"""Lightning module that orchestrates the RegMem few-shot anomaly detector."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import torch
+from lightning.pytorch.utilities.types import STEP_OUTPUT
+from torch import nn
+
+from anomalib import LearningType
+from anomalib.data import Batch
+from anomalib.metrics import Evaluator
+from anomalib.models.components import AnomalibModule, MemoryBankMixin
+from anomalib.post_processing import PostProcessor
+from anomalib.visualization import Visualizer
+
+from .torch_model import RegMemFewShotModel
+
+
+class RegMemFSAD(MemoryBankMixin, AnomalibModule):
+    """Few-shot anomaly detection model with feature registration and memory bank."""
+
+    def __init__(
+        self,
+        backbone: str = "resnet18",
+        layers: Sequence[str] = ("layer2", "layer3"),
+        pre_trained: bool = True,
+        coreset_sampling_ratio: float = 0.05,
+        num_neighbors: int = 5,
+        distribution_weights: Sequence[float] = (0.5, 0.3, 0.2),
+        mmd_sigma: float = 1.0,
+        learning_rate: float = 1e-4,
+        pre_processor: nn.Module | bool = True,
+        post_processor: nn.Module | bool = True,
+        evaluator: Evaluator | bool = True,
+        visualizer: Visualizer | bool = True,
+    ) -> None:
+        super().__init__(
+            pre_processor=pre_processor,
+            post_processor=post_processor,
+            evaluator=evaluator,
+            visualizer=visualizer,
+        )
+
+        self.model = RegMemFewShotModel(
+            backbone=backbone,
+            layers=tuple(layers),
+            pre_trained=pre_trained,
+            coreset_sampling_ratio=coreset_sampling_ratio,
+            num_neighbors=num_neighbors,
+            distribution_weights=tuple(distribution_weights),
+            mmd_sigma=mmd_sigma,
+        )
+        self.learning_rate = learning_rate
+
+    def on_train_start(self) -> None:
+        self.model.reset()
+
+    def training_step(self, batch: Batch, *args, **kwargs) -> torch.Tensor:
+        del args, kwargs
+        loss = self.model.registration_loss(batch.image)
+        self.log("train/registration_loss", loss, prog_bar=True)
+        self.model.collect_support_features(batch.image)
+        return loss
+
+    def fit(self) -> None:
+        self.model.build_memory_bank()
+
+    def validation_step(self, batch: Batch, *args, **kwargs) -> STEP_OUTPUT:
+        del args, kwargs
+        predictions = self.model.predict(batch.image)
+        return batch.update(image_scores=predictions.scores, anomaly_maps=predictions.anomaly_maps)
+
+    def test_step(self, batch: Batch, *args, **kwargs) -> STEP_OUTPUT:
+        return self.validation_step(batch, *args, **kwargs)
+
+    def predict_step(self, batch: Batch, *args, **kwargs) -> STEP_OUTPUT:
+        return self.validation_step(batch, *args, **kwargs)
+
+    def configure_optimizers(self) -> Any:
+        return torch.optim.Adam(self.parameters(), lr=self.learning_rate)
+
+    @property
+    def learning_type(self) -> LearningType:
+        return LearningType.ONE_CLASS
+
+    @property
+    def trainer_arguments(self) -> dict[str, Any]:
+        return {"gradient_clip_val": 0.0, "max_epochs": 50, "num_sanity_val_steps": 0}
+
+    @staticmethod
+    def configure_post_processor() -> PostProcessor:
+        return PostProcessor()
+

--- a/src/anomalib/models/image/regmemfsad/torch_model.py
+++ b/src/anomalib/models/image/regmemfsad/torch_model.py
@@ -1,0 +1,107 @@
+"""Low level PyTorch module for the RegMem few-shot anomaly detector."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+from torch import Tensor
+import torch.nn as nn
+
+from anomalib.models.components.regmem import (
+    DistributionEstimator,
+    FeatureRegistrationModule,
+    PatchMemoryBank,
+)
+
+
+@dataclass
+class AnomalyPredictions:
+    """Container storing anomaly scores and maps."""
+
+    scores: Tensor
+    anomaly_maps: dict[str, Tensor]
+
+
+class RegMemFewShotModel(nn.Module):
+    """Encapsulates registration, memory bank construction and scoring."""
+
+    def __init__(
+        self,
+        backbone: str = "resnet18",
+        layers: tuple[str, ...] = ("layer2", "layer3"),
+        pre_trained: bool = True,
+        coreset_sampling_ratio: float = 0.05,
+        num_neighbors: int = 5,
+        distribution_weights: tuple[float, float, float] = (0.5, 0.3, 0.2),
+        mmd_sigma: float = 1.0,
+    ) -> None:
+        super().__init__()
+        self.layers = list(layers)
+        self.num_neighbors = num_neighbors
+        self.registration = FeatureRegistrationModule(
+            backbone=backbone,
+            layers=layers,
+            pre_trained=pre_trained,
+        )
+        self.memory_bank = PatchMemoryBank(layers=self.layers, coreset_sampling_ratio=coreset_sampling_ratio)
+        self.distribution_estimator = DistributionEstimator(
+            combine_weights=distribution_weights, mmd_sigma=mmd_sigma
+        )
+
+    def reset(self) -> None:
+        self.memory_bank.reset()
+
+    def collect_support_features(self, images: Tensor) -> Tensor:
+        features = self.registration.extract(images)
+        registered = self.registration.register_support_batch(features)
+        self.memory_bank.update(registered)
+        return torch.tensor(0.0, device=images.device)
+
+    def build_memory_bank(self) -> None:
+        self.memory_bank.build()
+        if not self.memory_bank.memory:
+            msg = "Memory bank is empty. Ensure that support features are collected before calling build_memory_bank()."
+            raise RuntimeError(msg)
+        memory = {layer: self.memory_bank.get(layer).features for layer in self.memory_bank.memory}
+        self.distribution_estimator.fit(memory)
+
+    def _score_layer(self, layer: str, query: Tensor) -> Tensor:
+        if layer not in self.memory_bank.memory:
+            msg = f"Requested layer {layer} not present in memory bank."
+            raise KeyError(msg)
+        item = self.memory_bank.get(layer)
+        query_flat = query.permute(0, 2, 3, 1).reshape(-1, query.shape[1])
+        distances = torch.cdist(query_flat, item.features, p=2)
+        knn = torch.topk(distances, k=min(self.num_neighbors, item.features.shape[0]), dim=1, largest=False)
+        knn_score = knn.values.mean(dim=1)
+        dist_score = self.distribution_estimator.score(layer, query_flat)
+        combined = 0.5 * knn_score + 0.5 * dist_score
+        return combined
+
+    def predict(self, images: Tensor) -> AnomalyPredictions:
+        features = self.registration.extract(images)
+        outputs = self.registration.align_query_to_prototypes(features)
+        anomaly_maps: dict[str, Tensor] = {}
+        image_scores = []
+        for layer in self.layers:
+            aligned_support = outputs.aligned_support[layer]
+            scores = self._score_layer(layer, aligned_support)
+            batch, _, height, width = aligned_support.shape
+            anomaly_map = scores.view(batch, height, width)
+            anomaly_maps[layer] = anomaly_map
+            image_scores.append(anomaly_map.view(batch, -1).topk(k=10, dim=1).values.mean(dim=1))
+
+        stacked_scores = torch.stack(image_scores, dim=0)
+        final_scores = stacked_scores.mean(dim=0)
+        return AnomalyPredictions(scores=final_scores, anomaly_maps=anomaly_maps)
+
+    def registration_loss(self, images: Tensor) -> Tensor:
+        if images.shape[0] < 2:
+            return torch.tensor(0.0, device=images.device)
+        perm = torch.randperm(images.shape[0], device=images.device)
+        half = images.shape[0] // 2
+        support = images[perm[:half]]
+        query = images[perm[half : 2 * half]]
+        return self.registration.compute_registration_loss(support, query)
+


### PR DESCRIPTION
## Summary
- add reusable registration, memory bank, and distribution estimator components for few-shot pipelines
- implement the RegMem few-shot anomaly detector with Lightning integration and export it from the image models package

## Testing
- python -m compileall src/anomalib/models/components/regmem src/anomalib/models/image/regmemfsad

------
https://chatgpt.com/codex/tasks/task_e_68e23dbf001c8321b346d6a7ec00b5bf