### PR TITLE
Fix RegMem FSAD prediction outputs

### DIFF
--- a/src/anomalib/models/image/regmemfsad/lightning_model.py
+++ b/src/anomalib/models/image/regmemfsad/lightning_model.py
@@ -71,7 +71,7 @@ class RegMemFSAD(MemoryBankMixin, AnomalibModule):
     def validation_step(self, batch: Batch, *args, **kwargs) -> STEP_OUTPUT:
         del args, kwargs
         predictions = self.model.predict(batch.image)
-        return batch.update(image_scores=predictions.scores, anomaly_maps=predictions.anomaly_maps)
+        return batch.update(pred_score=predictions.pred_score, anomaly_map=predictions.anomaly_map)
 
     def test_step(self, batch: Batch, *args, **kwargs) -> STEP_OUTPUT:
         return self.validation_step(batch, *args, **kwargs)


### PR DESCRIPTION
## Summary
- aggregate RegMem few-shot anomaly predictions into standard `pred_score` and `anomaly_map` tensors
- update the Lightning validation step to forward the new prediction keys

## Testing
- python - <<'PY'
import torch
from anomalib.models.image.regmemfsad.torch_model import RegMemFewShotModel

model = RegMemFewShotModel(pre_trained=False)
support = torch.rand(8, 3, 256, 256)
model.collect_support_features(support)
model.build_memory_bank()
query = torch.rand(2, 3, 256, 256)
predictions = model.predict(query)
print('pred_score shape:', predictions.pred_score.shape)
print('anomaly_map shape:', predictions.anomaly_map.shape)
print('layer keys:', list(predictions.layer_anomaly_maps))
PY *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68e29d77909483219cdfee7645970276